### PR TITLE
fix: html webpack plugin inject false

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "rules": {
       "eqeqeq": "off",
       "no-eq-null": "off",
+      "no-await-in-loop": "off",
       "unicorn/no-reduce": "off",
       "eslint-comments/no-unused-disable": "off",
       "import/no-extraneous-dependencies": "off",

--- a/src/index.js
+++ b/src/index.js
@@ -276,8 +276,18 @@ export default class DynamicCdnWebpackPlugin {
                     pluginName,
                     alterAssets
                 );
+            } else if (
+                compilation.hooks &&
+                compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration
+            ) {
+                compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration.tapAsync(
+                    pluginName,
+                    alterAssets
+                );
             } else {
-                compilation.plugin('html-webpack-plugin-before-html-processing', alterAssets);
+                throw new Error(
+                    '@talend/dynamic-cdn-webpack-plugin support only webpack-html-plugin 3.2 and 4.x'
+                );
             }
         });
     }


### PR DESCRIPTION
when use with inject to false we lost the assets.
This is due on how the assets are added in html-webpack-plugin.
Moving from html-webpack-plugin-before-html-processing to html-webpack-plugin-before-html-generation fix the issue