### PR TITLE
fix: support modules without var name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ export default class DynamicCdnWebpackPlugin {
                 if (varName === false) {
                     factory(data, cb);
                 } else if (varName == null) {
-                    cb(null);
+                    cb(null, new ExternalModule('{}', 'var', modulePath));
                 } else {
                     cb(null, new ExternalModule(varName, 'var', modulePath));
                 }


### PR DESCRIPTION
**The issue**

When we define a module that is on CDN but does not expose a variable, webpack doesn't find the module. It replace the module definition by a WebpackMissingModule that throws a `Cannot find module` error.
This happens for `@babel/polyfill` for example, that doesn't export a global variable but set polyfills.

This is due to the execution of the callback in `tap()` code in case of no var provided in module-to-cdn definition.
```
cb(null, /* no module definition here */)
```

**The fix**

In supported case (with a var name), the plugin define an external module
```
 cb(null, new ExternalModule(varName, 'var', modulePath));
```

The `varName` is used to set the exposed global variable as export of a webpack wrapper around the module.
```
`module.export = ${varName};`
```

In case of no var provided, let's expose an empty object as varName so webpack wrapper export an empty object.
